### PR TITLE
Ensure other SumTypes are invalid for placeholder case

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,9 +81,10 @@ function Setup(T, { checkTypes , _env=[] }){
         /* eslint-enable immutable/no-this */
     }
 
-    function staticCase(options, b, ...args){
+    const staticCaseT = T => function staticCase(options, b, ...args){
         const f = options[b._name]
-        if ( b && !b._name ) {
+
+        if ( !T._test(b) ) {
             throw new TypeError(
                 'Value was not created using UnionType constructor'
                 +' Value: '+R.toString(b)
@@ -211,13 +212,6 @@ function Setup(T, { checkTypes , _env=[] }){
         }
     }
 
-
-    function boundStaticCase(options){
-        /* eslint-disable immutable/no-this */
-        return staticCase(options, this)
-        /* eslint-enable immutable/no-this */
-    }
-
     env.push(..._env)
 
     const def =
@@ -241,6 +235,15 @@ function Setup(T, { checkTypes , _env=[] }){
             Object.keys(rawCases)
 
         env.push(Type)
+
+        const staticCase = staticCaseT(Type)
+
+        function boundStaticCase(options){
+            /* eslint-disable immutable/no-this */
+            return staticCase(options, this)
+            /* eslint-enable immutable/no-this */
+        }
+
 
         const def = T.create({ checkTypes: checkTypes, env })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sum-type",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Descendant of paldepind/union-type with more descriptive error messages",
   "main": "index.js",
   "module": "lib/index.js",

--- a/test/test.js
+++ b/test/test.js
@@ -421,6 +421,18 @@ test('case throws if receives a value that isnt a subtype', function(t){
 
   }, /Value was not created using UnionType/, 'Placeholder requires subtype')
 
+  t.throws(function(){
+
+    Response.case({
+      _: () => t.fail(
+        'case should have thrown before executing'
+      )
+    }, ScheduleTask.Task('Hey hey') )
+
+  }, /Value was not created using UnionType/, 'Placeholder requires subtype')
+
+
+
   t.end()
 })
 


### PR DESCRIPTION
Previously we were just checking if an instance had the form of a SumType value, now we check if it passes the Type's _test function.