### PR TITLE
Expose one RecordType per case

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -205,6 +205,7 @@ function Setup(T, { checkTypes , _env=[] }){
                             ,_.unapply(_.zipObj(keys))
                         )
                     )
+                ,[k+'RecordType']: recordType
             }
 
             return r

--- a/test/test.js
+++ b/test/test.js
@@ -151,6 +151,26 @@ test('create instance methods declaratively', t => {
   t.end();
 });
 
+test('expose one RecordType per case', t => {
+
+  const id = { name: 'Identity', strMap: { value: T.String } }
+  /* eslint-disable */
+  const Identity =
+    Named( id.name
+         , { [ id.name ]: id.strMap }
+  );
+  const recordType = Identity[ id.name + 'RecordType' ]
+
+  /* eslint-enable */
+
+  t.equal( typeof recordType, 'object' )
+  t.equal( recordType.type, 'RECORD' );
+  t.deepEqual( recordType.keys
+             , T.RecordType( id.strMap ).keys
+             );
+  t.end();
+});
+
 test('Fields can be described in terms of other types', t => {
   const Point = Type(
     {Point: {x: Number, y: Number}}


### PR DESCRIPTION
Makes this possible:
```
const caseIs = ($T, caseName) => Ta =>
    $T[ caseName + 'RecordType' ].validate( Ta )
```
Also makes it possible to get to the individual field types in each case, which should make sum-type based field-level validation (validating individual form fields, for instance) easier to implement.